### PR TITLE
fix: buffered SFX + document macOS OpenAL startup race

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cd build && ./SuperMario2
 - [Architecture](docs/DESIGN.md)
 - [Roadmap](docs/ROADMAP.md)
 - [Build guide](docs/BUILD.md)
+- [Known issues](docs/KNOWN_ISSUES.md)
 
 ## Credits
 

--- a/SuperMario 2.0/Audio.cpp
+++ b/SuperMario 2.0/Audio.cpp
@@ -3,22 +3,30 @@
 
 
 
+namespace
+{
+	// Load a sound buffer and bind it to its voice, reporting failures.
+	void loadSfx(sf::SoundBuffer& buffer, sf::Sound& sound, const char* path)
+	{
+		if (!buffer.loadFromFile(path))
+			std::cerr << "Error: Failed to load audio from " << path << std::endl;
+		else
+			sound.setBuffer(buffer);
+	}
+}
+
 Audio::Audio()
 {
-	if (!jumpSound.openFromFile("Music/jump.wav"))
-		std::cerr << "Error: Failed to load audio from Music/jump.wav" << std::endl;
-	if (!deadSound.openFromFile("Music/dead.wav"))
-		std::cerr << "Error: Failed to load audio from Music/dead.wav" << std::endl;
-	if (!coinSound.openFromFile("Music/coin.wav"))
-		std::cerr << "Error: Failed to load audio from Music/coin.wav" << std::endl;
-	if (!shroomSound.openFromFile("Music/shroom.wav"))
-		std::cerr << "Error: Failed to load audio from Music/shroom.wav" << std::endl;
-	if (!stompSound.openFromFile("Music/stomp.wav"))
-		std::cerr << "Error: Failed to load audio from Music/stomp.wav" << std::endl;
 	if (!mainTheme.openFromFile("Music/maintheme.ogg"))
 		std::cerr << "Error: Failed to load audio from Music/maintheme.ogg" << std::endl;
-	if (!finishSound.openFromFile("Music/finish.wav"))
-		std::cerr << "Error: Failed to load audio from Music/finish.wav" << std::endl;
+	mainTheme.setLoop(true);
+
+	loadSfx(jumpBuffer, jumpSound, "Music/jump.wav");
+	loadSfx(deadBuffer, deadSound, "Music/dead.wav");
+	loadSfx(coinBuffer, coinSound, "Music/coin.wav");
+	loadSfx(shroomBuffer, shroomSound, "Music/shroom.wav");
+	loadSfx(stompBuffer, stompSound, "Music/stomp.wav");
+	loadSfx(finishBuffer, finishSound, "Music/finish.wav");
 }
 
 

--- a/SuperMario 2.0/Audio.h
+++ b/SuperMario 2.0/Audio.h
@@ -1,16 +1,29 @@
 #pragma once
 #include <SFML/Audio.hpp>
 
+// The looping background track is streamed with sf::Music (the right tool for
+// a multi-megabyte track); the short, frequently-overlapping effects are
+// preloaded sf::SoundBuffer/sf::Sound pairs. The original code streamed every
+// effect through sf::Music, which truncated overlapping sounds.
 class Audio
 {
 private:
-	sf::Music jumpSound;
-	sf::Music deadSound;
-	sf::Music coinSound;
-	sf::Music shroomSound;
-	sf::Music stompSound;
 	sf::Music mainTheme;
-	sf::Music finishSound;
+
+	sf::SoundBuffer jumpBuffer;
+	sf::SoundBuffer deadBuffer;
+	sf::SoundBuffer coinBuffer;
+	sf::SoundBuffer shroomBuffer;
+	sf::SoundBuffer stompBuffer;
+	sf::SoundBuffer finishBuffer;
+
+	sf::Sound jumpSound;
+	sf::Sound deadSound;
+	sf::Sound coinSound;
+	sf::Sound shroomSound;
+	sf::Sound stompSound;
+	sf::Sound finishSound;
+
 public:
 	Audio();
 	~Audio();

--- a/SuperMario 2.0/run.sh
+++ b/SuperMario 2.0/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Launch the game from the build directory, retrying past the intermittent
+# macOS startup crash caused by SFML 2.6 linking Apple's deprecated
+# OpenAL.framework (see docs/KNOWN_ISSUES.md). On Linux this just runs once.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BIN="$HERE/build/SuperMario2"
+ATTEMPTS="${1:-8}"
+
+if [[ ! -x "$BIN" ]]; then
+	echo "Build first: cmake -S '$HERE' -B '$HERE/build' && cmake --build '$HERE/build'" >&2
+	exit 1
+fi
+
+cd "$HERE/build" || exit 1
+for ((i = 1; i <= ATTEMPTS; i++)); do
+	./SuperMario2 &
+	pid=$!
+	sleep 2
+	if kill -0 "$pid" 2>/dev/null; then
+		wait "$pid"
+		exit $?
+	fi
+	wait "$pid"
+	echo "Audio-init crash on launch $i/$ATTEMPTS, retrying..." >&2
+done
+echo "Gave up after $ATTEMPTS attempts (see docs/KNOWN_ISSUES.md)." >&2
+exit 1

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,34 @@
+# Known issues
+
+## Intermittent crash on startup (macOS, Apple Silicon)
+
+**Symptom:** the game occasionally crashes immediately on launch with
+`EXC_BAD_ACCESS` / `SIGSEGV` before the window is usable. Re-launching works.
+
+**Cause:** this is *not* a bug in the game. Homebrew's `sfml@2` audio library
+links Apple's **deprecated `OpenAL.framework`**:
+
+```
+$ otool -L libsfml-audio.2.6.dylib | grep -i openal
+    /System/Library/Frameworks/OpenAL.framework/.../OpenAL
+```
+
+Apple deprecated that framework in macOS 10.15 and it races inside CoreAudio's
+HAL (`HAL_HardwarePlugIn_ObjectHasProperty` / `AudioDeviceGetPropertyInfo`)
+when OpenAL first opens the audio device. The crash happens on the first sound
+played, regardless of whether it is `sf::Music` or `sf::Sound`.
+
+**Workarounds:**
+
+- Use the retry launcher, which re-runs past a failed audio init:
+  ```sh
+  ./run.sh        # from the "SuperMario 2.0" directory
+  ```
+- Or simply launch again — a successful start runs normally for the whole
+  session.
+
+**Not affected:** Linux/CI builds, which use `openal-soft` (`libopenal-dev`)
+instead of the Apple framework, do not exhibit this race.
+
+A permanent fix requires SFML to link a modern `openal-soft` on macOS, which is
+a packaging concern outside this repository's source.


### PR DESCRIPTION
## Phase 1 — audio correctness & a documented platform crash

### Code
- Short effects now play from preloaded `sf::SoundBuffer`/`sf::Sound` pairs instead of streaming each through `sf::Music`. The old approach truncated overlapping effects and spun a decode thread per sound. The looping theme stays on `sf::Music` (the right tool for a 5 MB track), now `setLoop(true)`.
- Seven copy-pasted load blocks → one helper.

### The startup crash (investigated, root-caused)
An intermittent `SIGSEGV` on launch traces into CoreAudio's HAL (`AudioDeviceGetPropertyInfo`) from OpenAL device init. `otool -L` shows Homebrew's `sfml@2` links Apple's **deprecated `OpenAL.framework`**, which races on first device open on Apple Silicon. It fires on the first sound regardless of `sf::Music` vs `sf::Sound`, so it's a packaging issue, not game code. Documented in `docs/KNOWN_ISSUES.md` with a `run.sh` retry launcher. **Linux/CI (openal-soft) is unaffected.**

### Test
- Clean build (macOS, SFML 2.6.2). CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)