### PR TITLE
refactor: GameState machine (replace boolean soup)

### DIFF
--- a/SuperMario 2.0/Game.cpp
+++ b/SuperMario 2.0/Game.cpp
@@ -10,17 +10,12 @@ Game::Game(RenderWindow *window)
 	collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, COORDFILE);
 	if (!menuFont.loadFromFile(FONTFILE))
 		std::cerr << "Error: Failed to load font from " << FONTFILE << std::endl;
-	gamePaused = false;
-	gameOver = false;
-	viewingScores = false;
-	viewingRegistrationPage = false;
-	selectedMenu = 0;
 	for (int i = 0; i < nrOfMenuOptions; i++)
 	{
 		menu[i].setFont(menuFont);
 		menu[i].setString(menuOptions[i]);
 	}
-	menu[0].setFillColor(Color(Color::Red));
+	menu[0].setFillColor(Color::Red);
 }
 
 Game::Game()
@@ -40,39 +35,21 @@ void Game::runGame()
 	audio.themeMusicPlay();
 	while (window->isOpen())
 	{
+		// Consume events; each state interprets them its own way.
 		while (window->pollEvent(event))
 		{
-			
-			if (viewingRegistrationPage)
-			{
-				registerPlayerName();
-			}
-			else if (gamePaused)
-			{
-				drawMenu();
-			}
 			if (event.type == Event::Closed)
 				window->close();
-			if (event.type == Event::KeyPressed && event.key.code == Keyboard::Escape && !gameOver)
+			switch (state)
 			{
-				if (!gamePaused)
-				{
-					audio.themeMusicPause();
-					gamePaused = true;
-				}
-				else
-				{
-					audio.themeMusicPlay();
-					gamePaused = false;
-				}
-			}
-			else if (event.type == Event::KeyPressed && event.key.code == Keyboard::Space && !gamePaused)
-			{
-				collision->jump();
-				audio.jumpMusicPlay();
+			case GameState::Playing:      handlePlayingEvent(); break;
+			case GameState::Registration: registerPlayerName();  break;
+			default:                      handleMenuInput();      break; // any menu
 			}
 		}
-		if (!gamePaused)	
+
+		// Render exactly once per frame, driven by the current state.
+		if (state == GameState::Playing)
 		{
 			update();
 			collision->updateCharacter();
@@ -82,21 +59,27 @@ void Game::runGame()
 			{
 				audio.themeMusicPause();
 				audio.deadMusicPlay();
-				viewingRegistrationPage = true;
-				gameOver = true;
-				gamePaused = true;
+				playerName.clear();
+				state = GameState::Registration;
 			}
 			else if (collision->checkMarioFinishCollision())
 			{
 				audio.themeMusicPause();
 				audio.finishMusicPlay();
-				viewingRegistrationPage = true;
-				gameOver = true;
-				gamePaused = true;
+				playerName.clear();
+				state = GameState::Registration;
 			}
 			window->clear();
-			collision->draw(window, gamePaused);
+			collision->draw(window, false);
 			window->display();
+		}
+		else if (state == GameState::Registration)
+		{
+			drawRegistration();
+		}
+		else
+		{
+			drawMenu();
 		}
 	}
 }
@@ -117,123 +100,126 @@ void Game::update()
 	}
 }
 
-void Game::loadMainMenu()
+void Game::handlePlayingEvent()
 {
-	if (!viewingScores && !viewingRegistrationPage)
+	if (event.type != Event::KeyPressed)
+		return;
+	if (event.key.code == Keyboard::Escape)
 	{
-		menuOptions[0] = gameOver ? "New Game" : "Resume";
-		for (int i = 0; i < nrOfMenuOptions; i++)
-		{
-			menu[i].setString(menuOptions[i]);
-		}
+		audio.themeMusicPause();
+		enterMenu(GameState::PauseMenu);
 	}
+	else if (event.key.code == Keyboard::Space)
+	{
+		collision->jump();
+		audio.jumpMusicPlay();
+	}
+}
+
+void Game::resetLevel()
+{
+	delete collision;
+	collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, COORDFILE);
+	audio.themeMusicReset();
+	audio.themeMusicPlay();
+	state = GameState::Playing;
+}
+
+// Switch to a menu state and (re)build its labels and selection highlight.
+void Game::enterMenu(GameState menuState)
+{
+	state = menuState;
+	selectedMenu = 0;
+	menuOptions[0] = (menuState == GameState::GameOverMenu) ? "New Game" : "Resume";
 	for (int i = 0; i < nrOfMenuOptions; i++)
 	{
-		menu[i].setPosition(Vector2f(window->getView().getCenter().x, window->getView().getCenter().y / 2.5f * (i + 1)));
-		menu[i].setOrigin(menu[i].getLocalBounds().left + menu[i].getLocalBounds().width / 2.0f, menu[i].getLocalBounds().top + menu[i].getLocalBounds().height / 2.0f);
+		menu[i].setString(menuOptions[i]);
+		menu[i].setFillColor(Color::White);
+	}
+	menu[0].setFillColor(Color::Red);
+}
+
+void Game::positionMenu()
+{
+	for (int i = 0; i < nrOfMenuOptions; i++)
+	{
+		menu[i].setPosition(window->getView().getCenter().x,
+			window->getView().getCenter().y / 2.5f * (i + 1));
+		menu[i].setOrigin(menu[i].getLocalBounds().left + menu[i].getLocalBounds().width / 2.0f,
+			menu[i].getLocalBounds().top + menu[i].getLocalBounds().height / 2.0f);
 	}
 }
 
 void Game::drawMenu()
 {
+	positionMenu();
 	window->clear();
-	if (!viewingScores)
-	{
-		loadMainMenu();
-	}
 	for (int i = 0; i < nrOfMenuOptions; i++)
-	{
 		window->draw(menu[i]);
-	}
 	window->display();
-	handleMenuInput();
 }
 
 void Game::handleMenuInput()
 {
-	if (event.type == Event::KeyPressed && event.key.code == Keyboard::Up)
+	if (event.type != Event::KeyPressed)
+		return;
+	const Keyboard::Key key = event.key.code;
+
+	// The high-score list only offers "Back".
+	if (state == GameState::Highscores)
 	{
-		if (selectedMenu - 1 >= 0)
-		{
-			menu[selectedMenu].setFillColor(Color(Color::White));
-			selectedMenu--;
-			menu[selectedMenu].setFillColor(Color(Color::Red));
-		}
+		if (key == Keyboard::Return || key == Keyboard::Escape)
+			enterMenu(highscoreReturnState);
+		return;
 	}
-	else if (event.type == Event::KeyPressed && event.key.code == Keyboard::Down)
+
+	// Escape resumes a paused game.
+	if (key == Keyboard::Escape && state == GameState::PauseMenu)
 	{
-		if (selectedMenu + 1 < nrOfMenuOptions)
-		{
-			menu[selectedMenu].setFillColor(Color(Color::White));
-			selectedMenu++;
-			menu[selectedMenu].setFillColor(Color(Color::Red));
-		}
+		audio.themeMusicPlay();
+		state = GameState::Playing;
+		return;
 	}
-	else if (event.type == Event::KeyPressed && event.key.code == Keyboard::Return)
+
+	if (key == Keyboard::Up && selectedMenu > 0)
+	{
+		menu[selectedMenu].setFillColor(Color::White);
+		selectedMenu--;
+		menu[selectedMenu].setFillColor(Color::Red);
+	}
+	else if (key == Keyboard::Down && selectedMenu < nrOfMenuOptions - 1)
+	{
+		menu[selectedMenu].setFillColor(Color::White);
+		selectedMenu++;
+		menu[selectedMenu].setFillColor(Color::Red);
+	}
+	else if (key == Keyboard::Return)
 	{
 		switch (selectedMenu)
 		{
-		case 0: {
-			// New Game
-			if (gameOver && !viewingScores && !viewingRegistrationPage) 
-			{
-				delete collision;
-				collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, COORDFILE);
-				gameOver = false;
-				gamePaused = false;
-				audio.themeMusicReset();
-				audio.themeMusicPlay();
-			}
-			// Resume Game
-			else if (!gameOver && !viewingScores && !viewingRegistrationPage)
+		case 0: // Resume (pause) or New Game (game over)
+			if (state == GameState::PauseMenu)
 			{
 				audio.themeMusicPlay();
-				gamePaused = false;
-			}
-			break;
-		}
-		case 1: {
-			// Restart Game
-			if (!viewingScores && !viewingRegistrationPage)
-			{
-				delete collision;
-				collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, COORDFILE);
-				gameOver = false;
-				gamePaused = false;
-				audio.themeMusicReset();
-				audio.themeMusicPlay();
-			}
-			break;
-		}
-		case 2: {
-			// View Highscore
-			if (!viewingRegistrationPage)
-			{
-				viewingScores = true;
-				importHighScores(HIGHSCOREFILE, 3);
-				loadMainMenu();
-			}
-			break;
-		}
-		case 3: {
-			// Back / Quit game
-			if (viewingScores)
-			{
-				viewingScores = false;
-			}
-			else if (viewingRegistrationPage)
-			{
-				viewingRegistrationPage = false;
+				state = GameState::Playing;
 			}
 			else
-			{
-				// Quit Game
-				window->close();
-			}
-
+				resetLevel();
 			break;
-		}
-		default:
+		case 1: // Restart
+			resetLevel();
+			break;
+		case 2: // View high scores
+			highscoreReturnState = state;
+			importHighScores(HIGHSCOREFILE, nrOfMenuOptions - 1);
+			state = GameState::Highscores;
+			selectedMenu = nrOfMenuOptions - 1; // highlight "Back"
+			for (int i = 0; i < nrOfMenuOptions; i++)
+				menu[i].setFillColor(Color::White);
+			menu[selectedMenu].setFillColor(Color::Red);
+			break;
+		case 3: // Quit
+			window->close();
 			break;
 		}
 	}
@@ -298,27 +284,20 @@ void Game::registerPlayerName()
 		{
 			collision->saveMarioStats(HIGHSCOREFILE, playerName);
 			playerName.clear();
-			viewingRegistrationPage = false;
-			selectedMenu = 0; // hand control back to the game-over menu
-			for (int i = 0; i < nrOfMenuOptions; i++)
-				menu[i].setFillColor(Color::White);
-			menu[0].setFillColor(Color::Red);
-			return; // menu renders next frame
+			enterMenu(GameState::GameOverMenu);
 		}
 	}
+}
 
-	// Render the registration screen.
+void Game::drawRegistration()
+{
 	menu[0].setString("ENTER YOUR NAME");
 	menu[1].setString(playerName.empty() ? "_" : playerName);
 	menu[2].setString("");
 	menu[3].setString("Press ENTER to save");
 	for (int i = 0; i < nrOfMenuOptions; i++)
-	{
 		menu[i].setFillColor(i == 1 ? Color::Yellow : Color::White);
-		menu[i].setPosition(window->getView().getCenter().x, window->getView().getCenter().y / 2.5f * (i + 1));
-		menu[i].setOrigin(menu[i].getLocalBounds().left + menu[i].getLocalBounds().width / 2.0f,
-			menu[i].getLocalBounds().top + menu[i].getLocalBounds().height / 2.0f);
-	}
+	positionMenu();
 	window->clear();
 	for (int i = 0; i < nrOfMenuOptions; i++)
 		window->draw(menu[i]);

--- a/SuperMario 2.0/Game.h
+++ b/SuperMario 2.0/Game.h
@@ -9,21 +9,30 @@
 const int nrOfMenuOptions = 4;
 const std::size_t MAX_NAME_LENGTH = 12;
 
+// The single source of truth for what the game is currently doing. Replaces the
+// old quartet of overlapping booleans, so each screen is one explicit state.
+enum class GameState
+{
+	Playing,       // active gameplay
+	PauseMenu,     // paused mid-level
+	GameOverMenu,  // after a death or finish, name already recorded
+	Highscores,    // viewing the high-score list
+	Registration   // typing a name for the high-score table
+};
+
 class Game
 {
 private:
 	Audio audio;
 	sf::Event event;
-	sf::RenderWindow *window;
-	Collision *collision;
+	sf::RenderWindow *window = nullptr;
+	Collision *collision = nullptr;
 
-	bool gamePaused;
-	bool gameOver;
-	bool viewingScores;
-	bool viewingRegistrationPage;
+	GameState state = GameState::Playing;
+	GameState highscoreReturnState = GameState::PauseMenu; // where "Back" returns
 
 	sf::Font menuFont;
-	int selectedMenu;
+	int selectedMenu = 0;
 	sf::Text menu[nrOfMenuOptions];
 	std::string menuOptions[nrOfMenuOptions] = { "Resume", "Restart", "Highscore", "Quit" };
 	std::string containerString; // scratch buffer for high-score formatting
@@ -40,9 +49,13 @@ public:
 
 	void runGame();
 	void update();
-	void loadMainMenu();
+	void resetLevel();
+	void enterMenu(GameState menuState);
+	void positionMenu();
 	void drawMenu();
 	void handleMenuInput();
+	void handlePlayingEvent();
+	void drawRegistration();
 	void importHighScores(const std::string fileLocation, int NrOfScoresToView);
 	void registerPlayerName();
 };

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -8,7 +8,7 @@ code as the game evolves.
 
 | Class       | Responsibility |
 |-------------|----------------|
-| `Game`      | Top-level loop, window, event handling, menu/UI state machine, high-score I/O. Owns a `Collision`. |
+| `Game`      | Top-level loop, window, event handling, the `GameState` machine, menus, and high-score I/O. Owns a `Collision`. |
 | `Collision` | Level container "god object": owns Mario, the map, and the enemy/loot arrays; runs all collision math, entity spawning from the map, and finish detection. |
 | `Map`       | Renders the tiled world (a `sf::VertexArray`) plus a scrolling background; owns the camera `sf::View`. |
 | `Character` | Base entity: texture/sprite, position/velocity, gravity, jumping, animation, and character-vs-character overlap classification. |
@@ -17,6 +17,20 @@ code as the game evolves.
 | `Loot`      | A collectible: coin or power-up. |
 | `Audio`     | Loads and plays music + sound effects. |
 | `Constants` | Shared tunables (tile sizes, physics, boost, animation). |
+
+## Game states
+
+`Game` is driven by a single `GameState` enum (no overlapping booleans). Each
+frame, events are dispatched by the current state and the screen is rendered
+exactly once:
+
+```
+Playing ──Esc──► PauseMenu ──Resume/Esc──► Playing
+   │                 │
+   │ death/finish    ├─Restart──► Playing (fresh level)
+   ▼                 ├─Highscore► Highscores ──Back──► (previous menu)
+Registration ──Enter(name)──► GameOverMenu ──New Game/Restart──► Playing
+```
 
 ## Data flow
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ Status: ☐ todo · ◐ in progress · ☑ done
 - ☐ **Input & high-score fixes** — fix text entry (unicode vs scancode), make registration commit + transition, read the real high-score count, guard malformed files.
 
 ## Phase 2 — Foundation refactors
-- ☐ **`GameState` enum** — replace the four-boolean state soup with one state machine.
+- ☑ **`GameState` enum** — replace the four-boolean state soup with one state machine.
 - ☐ **`TileType` registry** — one source of truth for tile semantics (sprite, solidity, finish, spawn), shared by `Map` and `Collision`.
 - ☐ **`LevelManager`** — load multiple level data files; explicit per-level dimensions; level progression.
 


### PR DESCRIPTION
## Phase 2 — Foundation refactor (1/3)

Replaces the four overlapping booleans (`gamePaused`/`gameOver`/`viewingScores`/`viewingRegistrationPage`) — which allowed contradictory states and were checked in tangled combinations — with a single `GameState` enum: `Playing`, `PauseMenu`, `GameOverMenu`, `Highscores`, `Registration`.

### Why it matters
This is the keystone that lets new screens (title, story/cutscene, level-complete, win/credits) be added as **one more state**, not another boolean to cross-check everywhere.

### Changes
- Events dispatched by state; **render once per frame** after the event loop — fixes menus that only redrew when an event arrived and cleared/displayed per-event.
- Registration and the pause menu no longer run at the same time fighting over events.
- One `resetLevel()` helper replaces duplicated New Game/Restart blocks; `enterMenu()` centralises menu labels + highlight.
- State graph documented in `docs/DESIGN.md`.

No gameplay behaviour change — pure structure.

### Test
- Clean build (macOS, SFML 2.6.2); launches and runs. CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)