### PR TITLE
refactor: centralise tile semantics in TileType registry

### DIFF
--- a/SuperMario 2.0/Collision.cpp
+++ b/SuperMario 2.0/Collision.cpp
@@ -1,5 +1,6 @@
 #include "Collision.h"
 #include "Constants.h"
+#include "TileType.h"
 
 using namespace std;
 using namespace sf;
@@ -25,18 +26,18 @@ Collision::Collision(const string highScoreFileLocation, const string tileFileLo
 	{
 		for (int x = 0; x < COLLISION_MAP_WIDTH; x++)
 		{
-			if (collisionMap[x][y] == -1)
+			if (collisionMap[x][y] == tiles::Coin)
 			{
 				expandArray(loot, nrOfLoot, lootArrayCapacity);
 				loot[nrOfLoot] = new Loot(tileFileLocation, IntRect(0, 64, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), Vector2f((float)TILE_SIZE * x, (float)TILE_SIZE * y), true);
 				nrOfLoot++;
 			}
-			else if (collisionMap[x][y] == 9) {
+			else if (collisionMap[x][y] == tiles::BlockLoot) {
 				expandArray(loot, nrOfLoot, lootArrayCapacity);
 				loot[nrOfLoot] = new Loot(tileFileLocation, IntRect(0, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), Vector2f((float)TILE_SIZE * x, (float)TILE_SIZE * y), false);
 				nrOfLoot++;
 			}
-			else if (collisionMap[x][y] == 8)
+			else if (collisionMap[x][y] == tiles::EnemySpawn)
 			{
 				if (rand() % 4 > 1) {
 					gravity = DEFAULT_GRAVITY;
@@ -196,19 +197,11 @@ void Collision::updateCharTexture(const int nrOfTilesToView)
 
 bool Collision::isCollidable(Vector2f position) const
 {
-	bool collided = false;
 	int xPos = position.x / TILE_SIZE;
 	int yPos = position.y / TILE_SIZE;
 	if (xPos < 0 || xPos >= COLLISION_MAP_WIDTH || yPos < 0 || yPos >= COLLISION_MAP_HEIGHT)
 		return false;
-	if (collisionMap[xPos][yPos] != 0
-		&& collisionMap[xPos][yPos] != 9
-		&& collisionMap[xPos][yPos] != 8
-		&& collisionMap[xPos][yPos] != -1)
-	{
-		collided = true;
-	}
-	return collided;
+	return tiles::isSolid(collisionMap[xPos][yPos]);
 }
 
 bool Collision::collidingWithLeft(Vector2f currentPosition)
@@ -341,16 +334,11 @@ void Collision::checkMarioLootCollision()
 
 bool Collision::checkMarioFinishCollision()
 {
-	bool finished = false;
 	int xPos = (mario->getPosition().x / TILE_SIZE) + 1;
 	int yPos = mario->getPosition().y / TILE_SIZE;
 	if (xPos < 0 || xPos >= COLLISION_MAP_WIDTH || yPos < 0 || yPos >= COLLISION_MAP_HEIGHT)
 		return false;
-	if (collisionMap[xPos][yPos] == -4)
-	{
-		finished = true;
-	}
-	return finished;
+	return tiles::isFinish(collisionMap[xPos][yPos]);
 }
 
 void Collision::draw(RenderWindow * window, const bool paused)

--- a/SuperMario 2.0/Map.cpp
+++ b/SuperMario 2.0/Map.cpp
@@ -1,4 +1,5 @@
 #include "Map.h"
+#include "TileType.h"
 #include <iostream>
 
 using namespace std;
@@ -86,55 +87,9 @@ void Map::importMapFromFile(const string mapFileLocation)
 	{
 		while (fromFile >> tileType)
 		{
-			switch (tileType)
-			{
-			case 1: { // Floor
-				addTilesToVertexArray(0, 0, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 2: { // Blocks
-				addTilesToVertexArray(1, 0, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 3: { // LootBox
-				addTilesToVertexArray(0, 3, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 4: { // Pipe-topLeft
-				addTilesToVertexArray(2, 0, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 5: { // Pipe-topRight
-				addTilesToVertexArray(3, 0, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 6: { // Pipe-BottomLeft
-				addTilesToVertexArray(2, 1, Vector2f((float)x, (float)y));
-				break;
-			}
-			case 7: { // Pipe-BottomRight
-				addTilesToVertexArray(3, 1, Vector2f((float)x, (float)y));
-				break;
-			}
-			case -3: {
-				addTilesToVertexArray(1, 6, Vector2f((float)x, (float)y));
-				break;
-			}
-			case -4: {
-				addTilesToVertexArray(2, 6, Vector2f((float)x, (float)y));
-				break;
-			}
-			case -5: {
-				addTilesToVertexArray(3, 6, Vector2f((float)x, (float)y));
-				break;
-			}
-			case -6: {
-				addTilesToVertexArray(4, 6, Vector2f((float)x, (float)y));
-				break;
-			}
-			default:
-				break;
-			}
+			tiles::AtlasCell cell = tiles::atlasCell(tileType);
+			if (cell.x >= 0)
+				addTilesToVertexArray(cell.x, cell.y, Vector2f((float)x, (float)y));
 			if (fromFile.peek() == '\n')
 			{
 				fromFile.ignore();

--- a/SuperMario 2.0/TileType.h
+++ b/SuperMario 2.0/TileType.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Single source of truth for the meaning of every integer in a level file.
+// Both the renderer (Map) and the collision/spawn logic (Collision) consult
+// this, so tile semantics can no longer drift between the two.
+namespace tiles
+{
+	enum Tile : int
+	{
+		Empty          = 0,
+		Floor          = 1,
+		Block          = 2,
+		LootBox        = 3,  // decorative solid block
+		PipeTopLeft    = 4,
+		PipeTopRight   = 5,
+		PipeBottomLeft = 6,
+		PipeBottomRight = 7,
+		EnemySpawn     = 8,  // spawns an enemy; tile itself is empty
+		BlockLoot      = 9,  // spawns a power-up; tile itself is empty
+		Coin           = -1, // spawns a coin; tile itself is empty
+		FlagPole       = -3,
+		Finish         = -4, // reaching this completes the level
+		FlagMiddle     = -5,
+		FlagTop        = -6
+	};
+
+	// A cell (column, row) in the 16-px tileset to draw for a tile.
+	// {-1, -1} means the tile draws nothing (empty / pure spawn markers).
+	struct AtlasCell { int x; int y; };
+
+	inline AtlasCell atlasCell(int t)
+	{
+		switch (t)
+		{
+		case Floor:           return { 0, 0 };
+		case Block:           return { 1, 0 };
+		case LootBox:         return { 0, 3 };
+		case PipeTopLeft:     return { 2, 0 };
+		case PipeTopRight:    return { 3, 0 };
+		case PipeBottomLeft:  return { 2, 1 };
+		case PipeBottomRight: return { 3, 1 };
+		case FlagPole:        return { 1, 6 };
+		case Finish:          return { 2, 6 };
+		case FlagMiddle:      return { 3, 6 };
+		case FlagTop:         return { 4, 6 };
+		default:              return { -1, -1 };
+		}
+	}
+
+	// Everything blocks movement except empty space and the pure spawn markers
+	// (enemy, power-up, coin), whose tiles are walkable.
+	inline bool isSolid(int t)
+	{
+		return t != Empty && t != EnemySpawn && t != BlockLoot && t != Coin;
+	}
+
+	inline bool isFinish(int t) { return t == Finish; }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Status: ☐ todo · ◐ in progress · ☑ done
 
 ## Phase 2 — Foundation refactors
 - ☑ **`GameState` enum** — replace the four-boolean state soup with one state machine.
-- ☐ **`TileType` registry** — one source of truth for tile semantics (sprite, solidity, finish, spawn), shared by `Map` and `Collision`.
+- ☑ **`TileType` registry** — one source of truth for tile semantics (sprite, solidity, finish, spawn), shared by `Map` and `Collision`.
 - ☐ **`LevelManager`** — load multiple level data files; explicit per-level dimensions; level progression.
 
 ## Phase 3 — Core systems


### PR DESCRIPTION
## Phase 2 — Foundation refactor (2/3)

Tile meanings were duplicated as magic integers across `Map`'s render switch and `Collision`'s solidity/finish/spawn logic — the two could silently drift.

### Changes
- New `TileType.h`: named `enum Tile` + `atlasCell()`, `isSolid()`, `isFinish()`.
- `Map::importMapFromFile` looks up the atlas cell (was an 11-case switch).
- `Collision` uses `isSolid()`/`isFinish()` and named spawn tiles (`Coin`, `BlockLoot`, `EnemySpawn`).

`isSolid()` is the exact inverse of the old condition and `atlasCell()` reproduces the old mapping, so **rendering and collision are unchanged**. Adding a tile type is now a one-line edit in one place — prerequisite for the level loader and richer content.

### Test
- Clean build (macOS, SFML 2.6.2); launches/renders identically. CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)