### PR TITLE
feat: screen-space HUD + victory screen

### DIFF
--- a/SuperMario 2.0/CMakeLists.txt
+++ b/SuperMario 2.0/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     Loot.cpp
     Audio.cpp
     LevelManager.cpp
+    Hud.cpp
 )
 
 # Create executable

--- a/SuperMario 2.0/Collision.cpp
+++ b/SuperMario 2.0/Collision.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace sf;
 
-Collision::Collision(const string highScoreFileLocation, const string tileFileLocation, const string fontFileLocation, const string coordMapLocation)
+Collision::Collision(const string tileFileLocation, const string coordMapLocation)
 {
 	enemyArrayCapacity = 20;
 	lootArrayCapacity = 20;
@@ -13,7 +13,7 @@ Collision::Collision(const string highScoreFileLocation, const string tileFileLo
 	nrOfLoot = 0;
 	bool canFly;
 	float gravity;
-	mario = new Mario(tileFileLocation, IntRect(0, TILE_SIZE, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), fontFileLocation, Vector2f(160.0f, 0), Vector2f(2.0f, 0.0f), DEFAULT_GRAVITY, DEFAULT_JUMP_HEIGHT);
+	mario = new Mario(tileFileLocation, IntRect(0, TILE_SIZE, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), Vector2f(160.0f, 0), Vector2f(2.0f, 0.0f), DEFAULT_GRAVITY, DEFAULT_JUMP_HEIGHT);
 	enemy = new Enemy*[enemyArrayCapacity];
 	for (int i = 0; i < enemyArrayCapacity; i++) enemy[i] = nullptr;
 	loot = new Loot*[lootArrayCapacity];
@@ -176,6 +176,7 @@ void Collision::expandArray(T **&arr, int nrOfItems, int & capacity)
 }
 void Collision::updateCharacter()
 {
+	mario->updateTimers();
 	mario->updateCharacter(collidingWithTop(mario->getPosition()), collidingWithBottom(mario->getPosition()));
 	for (int i = 0; i < nrOfEnemies; i++)
 	{
@@ -346,12 +347,10 @@ bool Collision::checkMarioFinishCollision()
 	return tiles::isFinish(collisionMap[xPos][yPos]);
 }
 
-void Collision::draw(RenderWindow * window, const bool paused)
+void Collision::draw(RenderWindow * window)
 {
 	window->draw(*map);
 	mario->drawCharacter(window);
-
-	mario->updateAndDrawCoinsAndTime(window, paused);
 	for (int i = 0; i < nrOfEnemies; i++)
 	{
 		if (enemy[i] != nullptr)

--- a/SuperMario 2.0/Collision.h
+++ b/SuperMario 2.0/Collision.h
@@ -27,7 +27,7 @@ private:
 	int collisionMap[COLLISION_MAP_WIDTH][COLLISION_MAP_HEIGHT];
 
 public:
-	Collision(const std::string highScoreFileLocation, const std::string tileFileLocation, const std::string fontFileLocation, const std::string coordMapLocation);
+	Collision(const std::string tileFileLocation, const std::string coordMapLocation);
 	~Collision();
 	void MarioMoveLeft();
 	void MarioMoveRight();
@@ -49,7 +49,7 @@ public:
 	bool checkMarioHostileCollision();
 	void checkMarioLootCollision();
 	bool checkMarioFinishCollision();
-	void draw(sf::RenderWindow *window, const bool paused);
+	void draw(sf::RenderWindow *window);
 	void saveMarioStats(const std::string HighScoreFileLocation, const std::string name) const;
 	PlayerStats getMarioStats() const;
 	void applyMarioStats(const PlayerStats &stats);

--- a/SuperMario 2.0/Game.cpp
+++ b/SuperMario 2.0/Game.cpp
@@ -22,8 +22,9 @@ namespace
 Game::Game(RenderWindow *window)
 {
 	this->window = window;
-	collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, levelManager.currentFile());
+	collision = new Collision(TILEFILE, levelManager.currentFile());
 	window->setTitle("Super Mario 2.0 - " + levelManager.currentName());
+	hud.load(FONTFILE);
 	if (!menuFont.loadFromFile(FONTFILE))
 		std::cerr << "Error: Failed to load font from " << FONTFILE << std::endl;
 	if (!titleFont.loadFromFile(TITLEFONTFILE))
@@ -63,6 +64,11 @@ void Game::runGame()
 			case GameState::Title:
 			case GameState::Story:        handleIntroEvent();   break;
 			case GameState::Playing:      handlePlayingEvent(); break;
+			case GameState::Victory:
+				if (event.type == Event::KeyPressed &&
+					(event.key.code == Keyboard::Return || event.key.code == Keyboard::Space))
+					state = GameState::Registration; // go record the winning run
+				break;
 			case GameState::Registration: registerPlayerName();  break;
 			default:                      handleMenuInput();      break; // any menu
 			}
@@ -98,16 +104,22 @@ void Game::runGame()
 				}
 				else
 				{
-					// Finished the final level: record the run.
+					// Beat the final level: celebrate, then record the run.
 					audio.themeMusicPause();
 					audio.finishMusicPlay();
+					finalStats = collision->getMarioStats();
 					playerName.clear();
-					state = GameState::Registration;
+					state = GameState::Victory;
 				}
 			}
 			window->clear();
-			collision->draw(window, false);
+			collision->draw(window);
+			hud.draw(window, collision->getMarioStats(), levelManager.currentName());
 			window->display();
+		}
+		else if (state == GameState::Victory)
+		{
+			drawVictory();
 		}
 		else if (state == GameState::Registration)
 		{
@@ -160,7 +172,7 @@ void Game::loadLevel(bool carryStats)
 	if (carryStats)
 		carried = collision->getMarioStats();
 	delete collision;
-	collision = new Collision(HIGHSCOREFILE, TILEFILE, FONTFILE, levelManager.currentFile());
+	collision = new Collision(TILEFILE, levelManager.currentFile());
 	if (carryStats)
 		collision->applyMarioStats(carried);
 	window->setTitle("Super Mario 2.0 - " + levelManager.currentName());
@@ -411,5 +423,19 @@ void Game::drawStory()
 		y += 48;
 	}
 	drawCenteredLine(window, menuFont, "Press ENTER to begin", 24, Color(255, 210, 60), cx, 470);
+	window->display();
+}
+
+void Game::drawVictory()
+{
+	window->setView(window->getDefaultView());
+	const float cx = window->getDefaultView().getCenter().x;
+	window->clear(Color(20, 20, 60));
+	drawCenteredLine(window, titleFont, "YOU WIN!", 56, Color(255, 210, 60), cx, 150);
+	drawCenteredLine(window, menuFont, "The Star of the Mushroom Kingdom is safe.", 24, Color::White, cx, 240);
+	drawCenteredLine(window, menuFont, "Coins  " + to_string(finalStats.coins), 26, Color::White, cx, 310);
+	drawCenteredLine(window, menuFont, "Enemies defeated  " + to_string(finalStats.enemies), 26, Color::White, cx, 350);
+	drawCenteredLine(window, menuFont, "Time  " + to_string(finalStats.time), 26, Color::White, cx, 390);
+	drawCenteredLine(window, menuFont, "Press ENTER to record your score", 22, Color(255, 210, 60), cx, 470);
 	window->display();
 }

--- a/SuperMario 2.0/Game.h
+++ b/SuperMario 2.0/Game.h
@@ -6,6 +6,7 @@
 #include "Collision.h"
 #include "Audio.h"
 #include "LevelManager.h"
+#include "Hud.h"
 
 const int nrOfMenuOptions = 4;
 const std::size_t MAX_NAME_LENGTH = 12;
@@ -18,6 +19,7 @@ enum class GameState
 	Story,         // intro narrative, shown once before the first level
 	Playing,       // active gameplay
 	PauseMenu,     // paused mid-level
+	Victory,       // beat the final level
 	GameOverMenu,  // after a death or finish, name already recorded
 	Highscores,    // viewing the high-score list
 	Registration   // typing a name for the high-score table
@@ -32,6 +34,8 @@ private:
 	Collision *collision = nullptr;
 
 	LevelManager levelManager;
+	Hud hud;
+	PlayerStats finalStats; // snapshot of the run when the game is beaten
 	GameState state = GameState::Title;
 	GameState highscoreReturnState = GameState::PauseMenu; // where "Back" returns
 
@@ -57,6 +61,7 @@ public:
 	void handleIntroEvent();
 	void drawTitle();
 	void drawStory();
+	void drawVictory();
 	void loadLevel(bool carryStats);
 	void resetLevel();
 	void advanceLevel();

--- a/SuperMario 2.0/Hud.cpp
+++ b/SuperMario 2.0/Hud.cpp
@@ -1,0 +1,42 @@
+#include "Hud.h"
+#include <iostream>
+
+using namespace sf;
+using namespace std;
+
+void Hud::load(const string &fontFileLocation)
+{
+	if (!font.loadFromFile(fontFileLocation))
+		std::cerr << "Error: Failed to load font from " << fontFileLocation << std::endl;
+	for (Text *t : { &levelText, &coinsText, &timeText, &enemiesText })
+	{
+		t->setFont(font);
+		t->setCharacterSize(22);
+		t->setFillColor(Color::White);
+		t->setOutlineColor(Color::Black);
+		t->setOutlineThickness(2.0f);
+	}
+	levelText.setFillColor(Color(255, 210, 60));
+}
+
+void Hud::draw(RenderWindow *window, const PlayerStats &stats, const string &levelName)
+{
+	levelText.setString(levelName);
+	coinsText.setString("$ " + to_string(stats.coins));
+	timeText.setString("TIME " + to_string(stats.time));
+	enemiesText.setString("ENEMIES " + to_string(stats.enemies));
+
+	levelText.setPosition(14.0f, 8.0f);
+	coinsText.setPosition(320.0f, 8.0f);
+	timeText.setPosition(470.0f, 8.0f);
+	enemiesText.setPosition(640.0f, 8.0f);
+
+	// Render against the default view so the HUD ignores the level camera.
+	const View previous = window->getView();
+	window->setView(window->getDefaultView());
+	window->draw(levelText);
+	window->draw(coinsText);
+	window->draw(timeText);
+	window->draw(enemiesText);
+	window->setView(previous);
+}

--- a/SuperMario 2.0/Hud.h
+++ b/SuperMario 2.0/Hud.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+#include "Mario.h" // PlayerStats
+
+// The in-game heads-up display. Drawn in screen space (the window's default
+// view) so it stays fixed while the level scrolls underneath it.
+class Hud
+{
+private:
+	sf::Font font;
+	sf::Text levelText;
+	sf::Text coinsText;
+	sf::Text timeText;
+	sf::Text enemiesText;
+
+public:
+	Hud() = default;
+	void load(const std::string &fontFileLocation); // call once before draw()
+	void draw(sf::RenderWindow *window, const PlayerStats &stats, const std::string &levelName);
+};

--- a/SuperMario 2.0/Mario.cpp
+++ b/SuperMario 2.0/Mario.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace sf;
 
-Mario::Mario(const string TileLocation, const IntRect tilePositionInFile, const string fontFileLocation, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
+Mario::Mario(const string TileLocation, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
 	: Character(TileLocation, tilePositionInFile, position, velocity, gravity, jumpheight)
 {
 	coins = 0;
@@ -13,8 +13,6 @@ Mario::Mario(const string TileLocation, const IntRect tilePositionInFile, const 
 	boostTime = 0;
 	enemies = 0;
 	boosted = false;
-	if (!font.loadFromFile(fontFileLocation))
-		std::cerr << "Error: Failed to load font from " << fontFileLocation << std::endl;
 }
 
 Mario::~Mario()
@@ -22,38 +20,20 @@ Mario::~Mario()
 
 }
 
-void Mario::updateAndDrawCoinsAndTime(RenderWindow * window, const bool paused)
+// Advance the in-level timers once per gameplay frame: the survival clock and
+// the expiry of the temporary speed boost. The HUD itself is drawn by Hud.
+void Mario::updateTimers()
 {
-	timeSpent.setFont(font);
-	coinsTaken.setFont(font);
-	enemiesKilled.setFont(font);
-
-	if (!paused)
+	if (marioClock.getElapsedTime().asSeconds() > 1.0f)
 	{
-		if (marioClock.getElapsedTime().asSeconds() > 1.0f)
-		{
-			marioTime++;
-			marioClock.restart();
-		}
+		marioTime++;
+		marioClock.restart();
 	}
-	if (boosted)
+	if (boosted && marioTime >= boostTime)
 	{
-		if (marioTime >= boostTime)
-		{
-			boosted = false;
-			doubleVelocityX(boosted);
-		}
+		boosted = false;
+		doubleVelocityX(boosted);
 	}
-	
-	timeSpent.setString("TIME: " + to_string(marioTime));
-	coinsTaken.setString("$: " + to_string(coins));
-	enemiesKilled.setString("Enemies: " + to_string(enemies));
-	timeSpent.setPosition(getPosition().x - 150, 0);
-	coinsTaken.setPosition(getPosition().x, 0);
-	enemiesKilled.setPosition(getPosition().x + 100, 0);
-	window->draw(timeSpent);
-	window->draw(coinsTaken);
-	window->draw(enemiesKilled);
 }
 
 void Mario::increaseCoins()

--- a/SuperMario 2.0/Mario.h
+++ b/SuperMario 2.0/Mario.h
@@ -20,14 +20,12 @@ private:
 	int enemies;
 	bool boosted;
 	int boostTime;
-	sf::Font font;
-	sf::Text coinsTaken, timeSpent, enemiesKilled;
 	sf::Clock marioClock;
 
 public:
-	Mario(const std::string TileLocation, const sf::IntRect tilePositionInFile, const std::string fontFileLocation, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
+	Mario(const std::string TileLocation, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
 	~Mario();
-	void updateAndDrawCoinsAndTime(sf::RenderWindow *window, const bool paused);
+	void updateTimers();
 	void increaseCoins();
 	void increaseEnemiesKilled();
 	void changeMarioVelocityX();

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,6 +10,7 @@ code as the game evolves.
 |-------------|----------------|
 | `Game`      | Top-level loop, window, event handling, the `GameState` machine, menus, and high-score I/O. Owns a `Collision` and a `LevelManager`. |
 | `LevelManager` | The ordered list of levels and a cursor; hands out the current level file and advances between levels. |
+| `Hud`       | The in-game heads-up display (level / coins / time / enemies), drawn in screen space so it stays fixed while the level scrolls. |
 | `Collision` | Level container "god object": owns Mario, the map, and the enemy/loot arrays; runs all collision math, entity spawning from the map, and finish detection. |
 | `Map`       | Renders the tiled world (a `sf::VertexArray`) plus a scrolling background; owns the camera `sf::View`. |
 | `Character` | Base entity: texture/sprite, position/velocity, gravity, jumping, animation, and character-vs-character overlap classification. |
@@ -30,10 +31,13 @@ Title ──Enter──► Story ──Enter──► Playing
                                      │
 Playing ──Esc──► PauseMenu ──Resume/Esc──► Playing
    │                 │
-   │ death / final   ├─Restart──► Playing (fresh level)
-   │ finish          ├─Highscore► Highscores ──Back──► (previous menu)
-   ▼
-Registration ──Enter(name)──► GameOverMenu ──New Game/Restart──► Playing
+   │                 ├─Restart──► Playing (fresh level)
+   │ death           ├─Highscore► Highscores ──Back──► (previous menu)
+   │   │
+   │   ▼
+   │ Registration ──Enter(name)──► GameOverMenu ──New Game/Restart──► Playing
+   │
+   └ final-level finish ──► Victory ──Enter──► Registration
 
 (finishing a non-final level advances straight to the next level)
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,7 +34,7 @@ Status: ☐ todo · ◐ in progress · ☑ done
 - ☐ **Title screen + story/cutscene + win/credits flow.**
 
 ## Phase 6 — Polish & robustness
-- ☐ **UI/HUD module** decoupled from shared menu slots.
+- ◐ **UI/HUD module** decoupled from shared menu slots.
 - ☐ **Resource manager + smart pointers** (shared textures, `vector<unique_ptr>`).
 - ☐ **Save/progression persistence + externalised config.**
 


### PR DESCRIPTION
## Phase 3 — UI & endgame flow (2)

### HUD
The HUD was three strings positioned in **world space** relative to Mario, so it jittered/overlapped as the level scrolled. New **`Hud`** class draws level / coins / time / enemies in **screen space** (default view) with an outline, anchored along the top.

### Victory
Beating the final level previously dropped straight into name entry. Added a **`Victory`** state with the run totals and a celebratory message before recording the score.

### Cleanup (enabled by the HUD move)
- `Mario` keeps only timer logic (`updateTimers`, called from the update path); all drawing moves to `Hud`.
- Removed the now-unused font + 3 `Text` members from `Mario`, and dropped the **unused** highscore/font params from `Mario`'s and `Collision`'s constructors (`Collision(tileFile, levelFile)`).

### Test
- Clean build + runs (macOS, SFML 2.6.2). CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)