### PR TITLE
feat: lives system with respawn

### DIFF
--- a/SuperMario 2.0/Constants.h
+++ b/SuperMario 2.0/Constants.h
@@ -19,6 +19,9 @@ const float ENEMY_JUMP_HEIGHT = 10.0f;
 const int BOOST_DURATION = 10;
 const float BOOST_VELOCITY_INCREASE = 2.0f;
 
+// Lives
+const int STARTING_LIVES = 3;
+
 // Ground
 const float GROUND_HEIGHT = 550.0f;
 

--- a/SuperMario 2.0/Game.cpp
+++ b/SuperMario 2.0/Game.cpp
@@ -91,10 +91,21 @@ void Game::runGame()
 			collision->checkMarioLootCollision();
 			if (collision->checkMarioHostileCollision())
 			{
-				audio.themeMusicPause();
 				audio.deadMusicPlay();
-				playerName.clear();
-				state = GameState::Registration;
+				lives--;
+				if (lives > 0)
+				{
+					// Respawn: replay the current level, keeping the run totals.
+					loadLevel(true);
+					audio.themeMusicReset();
+					audio.themeMusicPlay();
+				}
+				else
+				{
+					audio.themeMusicPause();
+					playerName.clear();
+					state = GameState::Registration;
+				}
 			}
 			else if (collision->checkMarioFinishCollision())
 			{
@@ -114,7 +125,7 @@ void Game::runGame()
 			}
 			window->clear();
 			collision->draw(window);
-			hud.draw(window, collision->getMarioStats(), levelManager.currentName());
+			hud.draw(window, collision->getMarioStats(), levelManager.currentName(), lives);
 			window->display();
 		}
 		else if (state == GameState::Victory)
@@ -181,6 +192,7 @@ void Game::loadLevel(bool carryStats)
 // New Game / Restart: start over from the first level.
 void Game::resetLevel()
 {
+	lives = STARTING_LIVES;
 	levelManager.reset();
 	loadLevel(false);
 	audio.themeMusicReset();

--- a/SuperMario 2.0/Game.h
+++ b/SuperMario 2.0/Game.h
@@ -35,6 +35,7 @@ private:
 
 	LevelManager levelManager;
 	Hud hud;
+	int lives = STARTING_LIVES;
 	PlayerStats finalStats; // snapshot of the run when the game is beaten
 	GameState state = GameState::Title;
 	GameState highscoreReturnState = GameState::PauseMenu; // where "Back" returns

--- a/SuperMario 2.0/Hud.cpp
+++ b/SuperMario 2.0/Hud.cpp
@@ -8,7 +8,7 @@ void Hud::load(const string &fontFileLocation)
 {
 	if (!font.loadFromFile(fontFileLocation))
 		std::cerr << "Error: Failed to load font from " << fontFileLocation << std::endl;
-	for (Text *t : { &levelText, &coinsText, &timeText, &enemiesText })
+	for (Text *t : { &levelText, &livesText, &coinsText, &timeText, &enemiesText })
 	{
 		t->setFont(font);
 		t->setCharacterSize(22);
@@ -19,22 +19,25 @@ void Hud::load(const string &fontFileLocation)
 	levelText.setFillColor(Color(255, 210, 60));
 }
 
-void Hud::draw(RenderWindow *window, const PlayerStats &stats, const string &levelName)
+void Hud::draw(RenderWindow *window, const PlayerStats &stats, const string &levelName, int lives)
 {
 	levelText.setString(levelName);
+	livesText.setString("LIVES " + to_string(lives));
 	coinsText.setString("$ " + to_string(stats.coins));
 	timeText.setString("TIME " + to_string(stats.time));
 	enemiesText.setString("ENEMIES " + to_string(stats.enemies));
 
 	levelText.setPosition(14.0f, 8.0f);
-	coinsText.setPosition(320.0f, 8.0f);
-	timeText.setPosition(470.0f, 8.0f);
-	enemiesText.setPosition(640.0f, 8.0f);
+	livesText.setPosition(200.0f, 8.0f);
+	coinsText.setPosition(360.0f, 8.0f);
+	timeText.setPosition(500.0f, 8.0f);
+	enemiesText.setPosition(660.0f, 8.0f);
 
 	// Render against the default view so the HUD ignores the level camera.
 	const View previous = window->getView();
 	window->setView(window->getDefaultView());
 	window->draw(levelText);
+	window->draw(livesText);
 	window->draw(coinsText);
 	window->draw(timeText);
 	window->draw(enemiesText);

--- a/SuperMario 2.0/Hud.h
+++ b/SuperMario 2.0/Hud.h
@@ -10,6 +10,7 @@ class Hud
 private:
 	sf::Font font;
 	sf::Text levelText;
+	sf::Text livesText;
 	sf::Text coinsText;
 	sf::Text timeText;
 	sf::Text enemiesText;
@@ -17,5 +18,5 @@ private:
 public:
 	Hud() = default;
 	void load(const std::string &fontFileLocation); // call once before draw()
-	void draw(sf::RenderWindow *window, const PlayerStats &stats, const std::string &levelName);
+	void draw(sf::RenderWindow *window, const PlayerStats &stats, const std::string &levelName, int lives);
 };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@ Status: ☐ todo · ◐ in progress · ☑ done
 - ☑ **`LevelManager`** — load multiple level data files; explicit per-level dimensions; level progression.
 
 ## Phase 3 — Core systems
-- ☐ **Lives + checkpoints + respawn.**
+- ◐ **Lives + respawn** (checkpoints pending)
 - ☐ **Score + persistent screen-space HUD + level-complete results screen.**
 - ☐ **Mario power-state machine** (small / big / star invincibility).
 - ☐ **Power-up system** (coin, speed, grow, fire, star, 1-up) via polymorphic `onCollect`.


### PR DESCRIPTION
## Phase 3 — core mechanic: lives

Death was instant game over. Now there are lives (start = `STARTING_LIVES` = 3):

- A hostile hit or a fall costs one life. With lives left, the current level replays (run totals carried forward) and play continues; only at **zero** lives does the run end and ask for a name.
- New Game / Restart refills lives.
- HUD shows remaining lives.

Section checkpoints (respawn mid-level instead of restarting it) are tracked as a follow-up in the roadmap.

### Test
- Clean build + runs (macOS, SFML 2.6.2). CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)