### PR TITLE
refactor: share textures via a TextureManager

### DIFF
--- a/SuperMario 2.0/Boss.cpp
+++ b/SuperMario 2.0/Boss.cpp
@@ -3,8 +3,8 @@
 using namespace sf;
 using namespace std;
 
-Boss::Boss(const string TileLocation, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const int startingHealth)
-	: Enemy(TileLocation, tilePositionInFile, position, velocity, false /*canFly*/, gravity, 0.0f),
+Boss::Boss(const Texture &texture, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const int startingHealth)
+	: Enemy(texture, tilePositionInFile, position, velocity, false /*canFly*/, gravity, 0.0f),
 	  health(startingHealth)
 {
 	setBaseScale(3.5f);                   // visibly larger than a normal foe

--- a/SuperMario 2.0/Boss.h
+++ b/SuperMario 2.0/Boss.h
@@ -9,7 +9,7 @@ private:
 	int health;
 
 public:
-	Boss(const std::string TileLocation, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const int startingHealth);
+	Boss(const sf::Texture &texture, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const int startingHealth);
 
 	bool onStomped() override; // takes one hit; returns true only when defeated
 	bool isBoss() const override { return true; }

--- a/SuperMario 2.0/CMakeLists.txt
+++ b/SuperMario 2.0/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
     LevelManager.cpp
     Hud.cpp
     Boss.cpp
+    TextureManager.cpp
 )
 
 # Create executable

--- a/SuperMario 2.0/Character.cpp
+++ b/SuperMario 2.0/Character.cpp
@@ -6,7 +6,7 @@ using namespace std;
 using namespace sf;
 
 
-Character::Character(const string TileLocation, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
+Character::Character(const Texture &texture, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
 {
 	this->velocity = velocity;
 	this->gravity = gravity;
@@ -15,8 +15,6 @@ Character::Character(const string TileLocation, const IntRect tilePositionInFile
 	isJumping = false;
 	isMovingRight = true;
 
-	if (!texture.loadFromFile(TileLocation))
-		std::cerr << "Error: Failed to load texture from " << TileLocation << std::endl;
 	appearence.setTexture(texture);
 	appearence.setPosition(position);
 	appearence.setTextureRect(tilePositionInFile);

--- a/SuperMario 2.0/Character.h
+++ b/SuperMario 2.0/Character.h
@@ -6,7 +6,6 @@
 class Character
 {
 private:
-	sf::Texture texture;
 	sf::IntRect tilePosition;
 	sf::Sprite appearence;
 	sf::Vector2f velocity;
@@ -23,7 +22,7 @@ protected:
 	void setAppearanceColor(sf::Color color);
 
 public:
-	Character(const std::string TileLocation, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
+	Character(const sf::Texture &texture, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
 	Character();
 	virtual ~Character();
 

--- a/SuperMario 2.0/Collision.cpp
+++ b/SuperMario 2.0/Collision.cpp
@@ -6,10 +6,12 @@
 using namespace std;
 using namespace sf;
 
-Collision::Collision(const string tileFileLocation, const string coordMapLocation)
+Collision::Collision(TextureManager &textures, const string tileFileLocation, const string coordMapLocation)
 {
-	mario = make_unique<Mario>(tileFileLocation, IntRect(0, TILE_SIZE, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), Vector2f(160.0f, 0), Vector2f(2.0f, 0.0f), DEFAULT_GRAVITY, DEFAULT_JUMP_HEIGHT);
-	map = make_unique<Map>(COLLISION_MAP_WIDTH, COLLISION_MAP_HEIGHT, (float)TILE_TEXTURE_SIZE, (float)TILE_SIZE, coordMapLocation, tileFileLocation);
+	const Texture &tileTexture = textures.get(tileFileLocation);
+	const Texture &backgroundTexture = textures.get("Tiles/Mario_BG.JPG");
+	mario = make_unique<Mario>(tileTexture, IntRect(0, TILE_SIZE, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), Vector2f(160.0f, 0), Vector2f(2.0f, 0.0f), DEFAULT_GRAVITY, DEFAULT_JUMP_HEIGHT);
+	map = make_unique<Map>(COLLISION_MAP_WIDTH, COLLISION_MAP_HEIGHT, (float)TILE_TEXTURE_SIZE, (float)TILE_SIZE, coordMapLocation, tileTexture, backgroundTexture);
 	loadCollisionMap(coordMapLocation);
 
 	for (int y = 0; y < COLLISION_MAP_HEIGHT; y++)
@@ -29,7 +31,7 @@ Collision::Collision(const string tileFileLocation, const string coordMapLocatio
 			}
 			if (spawnLoot)
 			{
-				loots.push_back(make_unique<Loot>(tileFileLocation, pos, lootType));
+				loots.push_back(make_unique<Loot>(tileTexture, pos, lootType));
 			}
 			else if (collisionMap[x][y] == tiles::EnemySpawn)
 			{
@@ -47,11 +49,11 @@ Collision::Collision(const string tileFileLocation, const string coordMapLocatio
 					canFly = true;
 					enemyRect = IntRect(0, 96, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE);
 				}
-				enemies.push_back(make_unique<Enemy>(tileFileLocation, enemyRect, pos, Vector2f(1.0f, 0.0f), canFly, gravity, ENEMY_JUMP_HEIGHT));
+				enemies.push_back(make_unique<Enemy>(tileTexture, enemyRect, pos, Vector2f(1.0f, 0.0f), canFly, gravity, ENEMY_JUMP_HEIGHT));
 			}
 			else if (collisionMap[x][y] == tiles::BossSpawn)
 			{
-				enemies.push_back(make_unique<Boss>(tileFileLocation, IntRect(64, 0, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), pos, Vector2f(1.0f, 0.0f), DEFAULT_GRAVITY, BOSS_HEALTH));
+				enemies.push_back(make_unique<Boss>(tileTexture, IntRect(64, 0, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE), pos, Vector2f(1.0f, 0.0f), DEFAULT_GRAVITY, BOSS_HEALTH));
 			}
 		}
 	}

--- a/SuperMario 2.0/Collision.h
+++ b/SuperMario 2.0/Collision.h
@@ -11,6 +11,7 @@
 #include "Loot.h"
 #include "Audio.h"
 #include "Constants.h"
+#include "TextureManager.h"
 
 class Collision
 {
@@ -25,7 +26,7 @@ private:
 	bool bossDefeated = false; // set when this level's boss is beaten
 
 public:
-	Collision(const std::string tileFileLocation, const std::string coordMapLocation);
+	Collision(TextureManager &textures, const std::string tileFileLocation, const std::string coordMapLocation);
 	void MarioMoveLeft();
 	void MarioMoveRight();
 	void moveViewLeft();

--- a/SuperMario 2.0/Enemy.cpp
+++ b/SuperMario 2.0/Enemy.cpp
@@ -3,8 +3,8 @@
 using namespace std;
 using namespace sf;
 
-Enemy::Enemy(const string TileLocation, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const bool canFly, const float gravity, const float jumpheight) 
-	: Character(TileLocation, tilePositionInFile, position, velocity, gravity, jumpheight)
+Enemy::Enemy(const Texture &texture, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const bool canFly, const float gravity, const float jumpheight)
+	: Character(texture, tilePositionInFile, position, velocity, gravity, jumpheight)
 {
 	this->canFly = canFly;
 	collidedWithLeft = true;

--- a/SuperMario 2.0/Enemy.h
+++ b/SuperMario 2.0/Enemy.h
@@ -12,7 +12,7 @@ private:
 	bool collidedWithRight = false;
 
 public:
-	Enemy(const std::string TileLocation, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const bool canFly, const float gravity, const float jumpheight);
+	Enemy(const sf::Texture &texture, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const bool canFly, const float gravity, const float jumpheight);
 	Enemy();
 	virtual ~Enemy();
 	void fly();

--- a/SuperMario 2.0/Game.cpp
+++ b/SuperMario 2.0/Game.cpp
@@ -22,7 +22,7 @@ namespace
 Game::Game(RenderWindow *window)
 {
 	this->window = window;
-	collision = new Collision(TILEFILE, levelManager.currentFile());
+	collision = new Collision(textures, TILEFILE, levelManager.currentFile());
 	window->setTitle("Super Mario 2.0 - " + levelManager.currentName());
 	hud.load(FONTFILE);
 	if (!menuFont.loadFromFile(FONTFILE))
@@ -183,7 +183,7 @@ void Game::loadLevel(bool carryStats)
 	if (carryStats)
 		carried = collision->getMarioStats();
 	delete collision;
-	collision = new Collision(TILEFILE, levelManager.currentFile());
+	collision = new Collision(textures, TILEFILE, levelManager.currentFile());
 	if (carryStats)
 		collision->applyMarioStats(carried);
 	window->setTitle("Super Mario 2.0 - " + levelManager.currentName());

--- a/SuperMario 2.0/Game.h
+++ b/SuperMario 2.0/Game.h
@@ -7,6 +7,7 @@
 #include "Audio.h"
 #include "LevelManager.h"
 #include "Hud.h"
+#include "TextureManager.h"
 
 const int nrOfMenuOptions = 4;
 const std::size_t MAX_NAME_LENGTH = 12;
@@ -33,6 +34,7 @@ private:
 	sf::RenderWindow *window = nullptr;
 	Collision *collision = nullptr;
 
+	TextureManager textures;
 	LevelManager levelManager;
 	Hud hud;
 	int lives = STARTING_LIVES;

--- a/SuperMario 2.0/Loot.cpp
+++ b/SuperMario 2.0/Loot.cpp
@@ -1,6 +1,5 @@
 #include "Loot.h"
 #include "Constants.h"
-#include <iostream>
 
 using namespace std;
 using namespace sf;
@@ -12,11 +11,9 @@ namespace
 	const IntRect SHROOM_RECT(0, 16, TILE_TEXTURE_SIZE, TILE_TEXTURE_SIZE); // (0,1)
 }
 
-Loot::Loot(const string &tileLocation, Vector2f position, LootType type)
+Loot::Loot(const Texture &texture, Vector2f position, LootType type)
 {
 	this->type = type;
-	if (!texture.loadFromFile(tileLocation))
-		std::cerr << "Error: Failed to load texture from " << tileLocation << std::endl;
 	appearence.setTexture(texture);
 
 	// Sprite + tint per type. The tints distinguish the two mushrooms and the

--- a/SuperMario 2.0/Loot.h
+++ b/SuperMario 2.0/Loot.h
@@ -14,12 +14,11 @@ enum class LootType
 class Loot
 {
 private:
-	sf::Texture texture;
 	sf::Sprite appearence;
 	LootType type;
 
 public:
-	Loot(const std::string &tileLocation, sf::Vector2f position, LootType type);
+	Loot(const sf::Texture &texture, sf::Vector2f position, LootType type);
 	~Loot();
 	sf::Sprite getLootSprite() const;
 	LootType getType() const;

--- a/SuperMario 2.0/Map.cpp
+++ b/SuperMario 2.0/Map.cpp
@@ -6,7 +6,7 @@ using namespace std;
 using namespace sf;
 
 
-Map::Map(const int width, const int height, const float tileTextureDimension, const float tileWorldDimension, const string mapFileLocation, const string tileFileLocation)
+Map::Map(const int width, const int height, const float tileTextureDimension, const float tileWorldDimension, const string mapFileLocation, const Texture &tileset, const Texture &backgroundTexture)
 {
 	view.setSize(sf::Vector2f(900, 600));
 	view.setCenter(sf::Vector2f(450, 300));
@@ -15,19 +15,11 @@ Map::Map(const int width, const int height, const float tileTextureDimension, co
 	viewVelocity = Vector2f(2.0f, 0.0f);
 	this->tileTextureDimension = tileTextureDimension;
 	this->tileWorldDimension = tileWorldDimension;
-	if (!tileSet.loadFromFile(tileFileLocation))
-		std::cerr << "Error: Failed to load tileset from " << tileFileLocation << std::endl;
-	if (!backgroundTexture.loadFromFile("Tiles/Mario_BG.JPG"))
-		std::cerr << "Error: Failed to load background texture from Tiles/Mario_BG.JPG" << std::endl;
+	tileSet = &tileset;
 	background.setTexture(backgroundTexture);
 	vertexArray.setPrimitiveType(Quads);
 	vertexArray.resize(width * height * 4);
 	importMapFromFile(mapFileLocation);
-}
-
-Map::Map()
-{
-
 }
 
 Map::~Map()
@@ -110,7 +102,7 @@ void Map::importMapFromFile(const string mapFileLocation)
 void Map::draw(RenderTarget& target, RenderStates states) const
 {
 	target.setView(view);
-	states.texture = &tileSet;
+	states.texture = tileSet;
 	target.draw(background, states);
 	target.draw(vertexArray, states);
 }

--- a/SuperMario 2.0/Map.h
+++ b/SuperMario 2.0/Map.h
@@ -10,16 +10,14 @@ private:
 	int height;
 	sf::View view;
 	sf::Vector2f viewVelocity;
-	sf::Texture tileSet;
+	const sf::Texture *tileSet = nullptr;        // shared, owned by TextureManager
 	sf::Sprite background;
 	sf::VertexArray vertexArray;
 	float tileWorldDimension;
-	sf::Texture backgroundTexture;
 	float tileTextureDimension;
 
 public:
-	Map(const int width, const int height, const float tileTextureDimension, const float tileWorldDimension, const std::string mapFileLocation, const std::string tileFileLocation);
-	Map();
+	Map(const int width, const int height, const float tileTextureDimension, const float tileWorldDimension, const std::string mapFileLocation, const sf::Texture &tileset, const sf::Texture &backgroundTexture);
 	virtual ~Map();
 	void moveViewRight(const bool isBoosted);
 	void moveViewLeft(const bool isBoosted);

--- a/SuperMario 2.0/Mario.cpp
+++ b/SuperMario 2.0/Mario.cpp
@@ -5,8 +5,8 @@
 using namespace std;
 using namespace sf;
 
-Mario::Mario(const string TileLocation, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
-	: Character(TileLocation, tilePositionInFile, position, velocity, gravity, jumpheight)
+Mario::Mario(const Texture &texture, const IntRect tilePositionInFile, const Vector2f position, const Vector2f velocity, const float gravity, const float jumpheight)
+	: Character(texture, tilePositionInFile, position, velocity, gravity, jumpheight)
 {
 	coins = 0;
 	marioTime = 0;

--- a/SuperMario 2.0/Mario.h
+++ b/SuperMario 2.0/Mario.h
@@ -28,7 +28,7 @@ private:
 	sf::Clock hitClock;          // measures the post-hit grace period
 
 public:
-	Mario(const std::string TileLocation, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
+	Mario(const sf::Texture &texture, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const float gravity, const float jumpheight);
 	~Mario();
 	void updateTimers();
 	void increaseCoins();

--- a/SuperMario 2.0/TextureManager.cpp
+++ b/SuperMario 2.0/TextureManager.cpp
@@ -1,0 +1,17 @@
+#include "TextureManager.h"
+#include <iostream>
+
+// std::unordered_map guarantees that references to elements stay valid across
+// inserts/rehashes, so the references returned here remain usable for the
+// manager's lifetime.
+const sf::Texture &TextureManager::get(const std::string &path)
+{
+	auto it = cache.find(path);
+	if (it != cache.end())
+		return it->second;
+
+	sf::Texture &texture = cache[path];
+	if (!texture.loadFromFile(path))
+		std::cerr << "Error: Failed to load texture from " << path << std::endl;
+	return texture;
+}

--- a/SuperMario 2.0/TextureManager.h
+++ b/SuperMario 2.0/TextureManager.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+#include <unordered_map>
+
+// Loads each texture from disk at most once and hands out shared references.
+// Previously every Character, Loot and Map loaded its own copy of the tileset,
+// so a level decoded the same PNG dozens of times into dozens of GPU textures.
+// The owner (Game) must outlive every sprite that references a texture from here.
+class TextureManager
+{
+private:
+	std::unordered_map<std::string, sf::Texture> cache;
+
+public:
+	const sf::Texture &get(const std::string &path);
+};

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -19,6 +19,7 @@ code as the game evolves.
 | `Boss`      | `Enemy` subclass for the endgame: larger, tinted, and survives several stomps (HP); defeating it completes the boss level. |
 | `Loot`      | A typed collectible (`LootType`: coin, speed mushroom, grow mushroom, star). |
 | `Audio`     | Loads and plays music + sound effects. |
+| `TextureManager` | Loads each texture once and hands out shared references, so entities don't each reload the tileset. |
 | `Constants` | Shared tunables (tile sizes, physics, boost, animation). |
 
 ## Game states

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,7 +35,7 @@ Status: ☐ todo · ◐ in progress · ☑ done
 
 ## Phase 6 — Polish & robustness
 - ◐ **UI/HUD module** decoupled from shared menu slots.
-- ◐ **Resource manager + smart pointers** (vector<unique_ptr> done; texture cache pending) (shared textures, `vector<unique_ptr>`).
+- ☑ **Resource manager + smart pointers** (shared TextureManager + vector<unique_ptr>) (shared textures, `vector<unique_ptr>`).
 - ☐ **Save/progression persistence + externalised config.**
 
 ## Design principle


### PR DESCRIPTION
## Phase 6 — resource management (audit H3)

Every `Character`, `Loot` and `Map` loaded its **own** copy of the tileset, so a level decoded the same PNG dozens of times into dozens of identical GPU textures (and re-did it on every restart).

### Changes
- New **`TextureManager`**: loads each file at most once, returns shared `const sf::Texture&` (stable for its lifetime).
- Entities and `Map` take a `const sf::Texture&` instead of a path and no longer own a texture; `Map` holds a pointer to the shared tileset.
- `Game` owns the manager (outliving every sprite) and passes it to `Collision`, which fetches the tileset + background once and hands them down.

Eliminates the redundant per-entity disk loads and texture copies. **Behaviour unchanged.**

### Test
- Clean build + runs (macOS, SFML 2.6.2). CI builds Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)