### PR TITLE
test: headless unit tests + run in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Test
 
 on:
   push:
@@ -26,6 +26,10 @@ jobs:
         working-directory: "SuperMario 2.0"
         run: cmake --build build --parallel
 
+      - name: Run unit tests
+        working-directory: "SuperMario 2.0"
+        run: ctest --test-dir build --output-on-failure
+
       - name: Verify executable exists
         working-directory: "SuperMario 2.0"
         run: test -f build/SuperMario2 && echo "Build artifact OK"
@@ -46,6 +50,10 @@ jobs:
       - name: Build
         working-directory: "SuperMario 2.0"
         run: cmake --build build --parallel
+
+      - name: Run unit tests
+        working-directory: "SuperMario 2.0"
+        run: ctest --test-dir build --output-on-failure
 
       - name: Verify executable exists
         working-directory: "SuperMario 2.0"

--- a/SuperMario 2.0/CMakeLists.txt
+++ b/SuperMario 2.0/CMakeLists.txt
@@ -62,3 +62,9 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         "${CMAKE_SOURCE_DIR}/Levels"
         "$<TARGET_FILE_DIR:${PROJECT_NAME}>/Levels"
 )
+
+# Headless unit tests for the pure-logic parts (no SFML / GL context needed).
+enable_testing()
+add_executable(SuperMario2_tests tests/tests.cpp LevelManager.cpp)
+target_include_directories(SuperMario2_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+add_test(NAME unit COMMAND SuperMario2_tests)

--- a/SuperMario 2.0/tests/tests.cpp
+++ b/SuperMario 2.0/tests/tests.cpp
@@ -1,0 +1,97 @@
+// Lightweight headless unit tests for the pure-logic parts of the game (no
+// SFML / GL context needed), so they run anywhere including CI.
+#include "TileType.h"
+#include "LevelManager.h"
+
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+#define CHECK(cond)                                                       \
+	do {                                                                  \
+		if (!(cond)) {                                                    \
+			std::cerr << "FAIL: " << #cond << " (" << __FILE__ << ":"     \
+			          << __LINE__ << ")\n";                               \
+			++failures;                                                   \
+		}                                                                 \
+	} while (0)
+
+static void testTileSolidity()
+{
+	using namespace tiles;
+	// Spawn markers and empty space are walkable.
+	CHECK(!isSolid(Empty));
+	CHECK(!isSolid(Coin));
+	CHECK(!isSolid(EnemySpawn));
+	CHECK(!isSolid(BlockLoot));
+	CHECK(!isSolid(BossSpawn));
+	CHECK(!isSolid(GrowSpawn));
+	CHECK(!isSolid(StarSpawn));
+	// Structure tiles block movement.
+	CHECK(isSolid(Floor));
+	CHECK(isSolid(Block));
+	CHECK(isSolid(LootBox));
+	CHECK(isSolid(PipeTopLeft));
+	CHECK(isSolid(Finish));
+}
+
+static void testFinish()
+{
+	using namespace tiles;
+	CHECK(isFinish(Finish));
+	CHECK(!isFinish(Floor));
+	CHECK(!isFinish(Empty));
+	CHECK(!isFinish(FlagPole));
+}
+
+static void testAtlasCells()
+{
+	using namespace tiles;
+	CHECK(atlasCell(Floor).x == 0 && atlasCell(Floor).y == 0);
+	CHECK(atlasCell(Block).x == 1 && atlasCell(Block).y == 0);
+	// Pure spawn markers draw nothing.
+	CHECK(atlasCell(EnemySpawn).x == -1);
+	CHECK(atlasCell(Coin).x == -1);
+	CHECK(atlasCell(Empty).x == -1);
+}
+
+static void testLevelManager()
+{
+	LevelManager lm;
+	CHECK(lm.count() >= 2);
+	CHECK(lm.currentNumber() == 1);
+	CHECK(!lm.currentName().empty());
+	CHECK(lm.hasNext());
+
+	// Walk to the last level.
+	int guard = 0;
+	while (lm.hasNext() && guard++ < 100)
+		lm.advance();
+	CHECK(!lm.hasNext());
+	CHECK(lm.currentNumber() == lm.count());
+
+	// advance() past the end is a no-op.
+	const int last = lm.currentNumber();
+	lm.advance();
+	CHECK(lm.currentNumber() == last);
+
+	lm.reset();
+	CHECK(lm.currentNumber() == 1);
+}
+
+int main()
+{
+	testTileSolidity();
+	testFinish();
+	testAtlasCells();
+	testLevelManager();
+
+	if (failures == 0)
+	{
+		std::cout << "All tests passed.\n";
+		return 0;
+	}
+	std::cerr << failures << " test(s) failed.\n";
+	return 1;
+}


### PR DESCRIPTION
## Phase 0/quality — automated tests

The build was verified by CI but nothing exercised the logic. This adds a small assert-based test target (`SuperMario2_tests`) for the parts with **no SFML/GL dependency**, so it runs headless anywhere:

- `tiles::isSolid` / `isFinish` / `atlasCell` mapping for every tile type.
- `LevelManager` progression (count, advance past the end is a no-op, reset).

Registered with CTest and run via `ctest` in CI on **both Ubuntu and macOS** after the build, so a regression in those rules fails the pipeline.

### Test
- `ctest` passes locally (1/1). Now part of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)