### PR TITLE
fix: frame-rate-independent flying enemy

### DIFF
--- a/SuperMario 2.0/Constants.h
+++ b/SuperMario 2.0/Constants.h
@@ -37,3 +37,6 @@ const float ENEMY_DESPAWN_Y = (float)(COLLISION_MAP_HEIGHT * TILE_SIZE);
 
 // Animation
 const float ANIMATION_INTERVAL = 0.09f;
+
+// Flying enemies hop on a fixed time interval (frame-rate independent).
+const float FLY_JUMP_INTERVAL = 1.1f;

--- a/SuperMario 2.0/Enemy.cpp
+++ b/SuperMario 2.0/Enemy.cpp
@@ -1,4 +1,5 @@
 #include "Enemy.h"
+#include "Constants.h"
 
 using namespace std;
 using namespace sf;
@@ -18,12 +19,12 @@ Enemy::Enemy() : Character()
 
 void Enemy::fly()
 {
-	if (canFly) 
+	// Hop on a fixed time interval so the behaviour doesn't change with the
+	// frame rate (the old per-frame rand() made it FPS-dependent).
+	if (canFly && flyClock.getElapsedTime().asSeconds() >= FLY_JUMP_INTERVAL)
 	{
-		if (rand() % 101 > 99)
-		{
-			jump();
-		}
+		jump();
+		flyClock.restart();
 	}
 }
 

--- a/SuperMario 2.0/Enemy.h
+++ b/SuperMario 2.0/Enemy.h
@@ -10,6 +10,7 @@ private:
 	bool canFly = false;
 	bool collidedWithLeft = true;
 	bool collidedWithRight = false;
+	sf::Clock flyClock; // paces the hops of a flying enemy
 
 public:
 	Enemy(const sf::Texture &texture, const sf::IntRect tilePositionInFile, const sf::Vector2f position, const sf::Vector2f velocity, const bool canFly, const float gravity, const float jumpheight);


### PR DESCRIPTION
## Phase 4 — enemy AI

The flying enemy jumped on a per-frame `rand()` roll, so its hop rate scaled with FPS (audit item M4). Now it hops from a per-enemy clock at a fixed interval (`FLY_JUMP_INTERVAL`) — consistent regardless of frame rate.

### Test
- Build + `ctest` pass; runs. CI builds + tests Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)