### PR TITLE
feat: arcade SCORE in HUD + victory

### DIFF
--- a/SuperMario 2.0/Game.cpp
+++ b/SuperMario 2.0/Game.cpp
@@ -464,6 +464,7 @@ void Game::drawVictory()
 	drawCenteredLine(window, menuFont, "Coins  " + to_string(finalStats.coins), 26, Color::White, cx, 310);
 	drawCenteredLine(window, menuFont, "Enemies defeated  " + to_string(finalStats.enemies), 26, Color::White, cx, 350);
 	drawCenteredLine(window, menuFont, "Time  " + to_string(finalStats.time), 26, Color::White, cx, 390);
-	drawCenteredLine(window, menuFont, "Press ENTER to record your score", 22, Color(255, 210, 60), cx, 470);
+	drawCenteredLine(window, menuFont, "SCORE  " + to_string(scoreFor(finalStats)), 30, Color(255, 210, 60), cx, 432);
+	drawCenteredLine(window, menuFont, "Press ENTER to record your score", 22, Color(255, 210, 60), cx, 480);
 	window->display();
 }

--- a/SuperMario 2.0/Hud.cpp
+++ b/SuperMario 2.0/Hud.cpp
@@ -8,7 +8,7 @@ void Hud::load(const string &fontFileLocation)
 {
 	if (!font.loadFromFile(fontFileLocation))
 		std::cerr << "Error: Failed to load font from " << fontFileLocation << std::endl;
-	for (Text *t : { &levelText, &livesText, &coinsText, &timeText, &enemiesText })
+	for (Text *t : { &levelText, &livesText, &scoreText, &coinsText, &timeText, &enemiesText })
 	{
 		t->setFont(font);
 		t->setCharacterSize(22);
@@ -23,21 +23,24 @@ void Hud::draw(RenderWindow *window, const PlayerStats &stats, const string &lev
 {
 	levelText.setString(levelName);
 	livesText.setString("LIVES " + to_string(lives));
+	scoreText.setString("SCORE " + to_string(scoreFor(stats)));
 	coinsText.setString("$ " + to_string(stats.coins));
 	timeText.setString("TIME " + to_string(stats.time));
 	enemiesText.setString("ENEMIES " + to_string(stats.enemies));
 
 	levelText.setPosition(14.0f, 8.0f);
-	livesText.setPosition(200.0f, 8.0f);
-	coinsText.setPosition(360.0f, 8.0f);
-	timeText.setPosition(500.0f, 8.0f);
-	enemiesText.setPosition(660.0f, 8.0f);
+	livesText.setPosition(180.0f, 8.0f);
+	scoreText.setPosition(310.0f, 8.0f);
+	coinsText.setPosition(470.0f, 8.0f);
+	timeText.setPosition(580.0f, 8.0f);
+	enemiesText.setPosition(700.0f, 8.0f);
 
 	// Render against the default view so the HUD ignores the level camera.
 	const View previous = window->getView();
 	window->setView(window->getDefaultView());
 	window->draw(levelText);
 	window->draw(livesText);
+	window->draw(scoreText);
 	window->draw(coinsText);
 	window->draw(timeText);
 	window->draw(enemiesText);

--- a/SuperMario 2.0/Hud.h
+++ b/SuperMario 2.0/Hud.h
@@ -11,6 +11,7 @@ private:
 	sf::Font font;
 	sf::Text levelText;
 	sf::Text livesText;
+	sf::Text scoreText;
 	sf::Text coinsText;
 	sf::Text timeText;
 	sf::Text enemiesText;

--- a/SuperMario 2.0/Mario.cpp
+++ b/SuperMario 2.0/Mario.cpp
@@ -229,7 +229,7 @@ void Mario::sortScoreList(string playerNames[], int times[], int coins[], int en
 		posOfBest = i;
 		for (int k = i + 1; k < nrOfScores; k++)
 		{
-			if ((enemiesKilled[k] + coins[k]) > (enemiesKilled[posOfBest] + coins[posOfBest]))
+			if ((coins[k] * 100 + enemiesKilled[k] * 200) > (coins[posOfBest] * 100 + enemiesKilled[posOfBest] * 200))
 			{
 				posOfBest = k;
 			}

--- a/SuperMario 2.0/Mario.h
+++ b/SuperMario 2.0/Mario.h
@@ -12,6 +12,12 @@ struct PlayerStats
 	int enemies = 0;
 };
 
+// A single arcade score derived from the run totals.
+inline int scoreFor(const PlayerStats &s)
+{
+	return s.coins * 100 + s.enemies * 200;
+}
+
 class Mario : public Character
 {
 private:


### PR DESCRIPTION
## Phase 3 — scoring

Adds a single derived **SCORE** (`coins×100 + enemies×200`) shown live in the HUD and on the victory screen, and ranks the high-score table by the same formula (instead of a raw coins+enemies sum) so the leaderboard matches the on-screen score.

### Test
- Build + `ctest` pass; runs. CI builds + tests Ubuntu + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)