### PR TITLE
docs: refresh roadmap + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,23 @@ cmake --build build --parallel
 cd build && ./SuperMario2
 ```
 
+## Gameplay
+
+Race through five worlds and Bowser's Fortress to reclaim the stolen Star.
+Stomp enemies, grab coins, and collect power-ups: a **green mushroom** makes
+you big (you survive one hit), a **red mushroom** boosts your speed, and a
+**star** makes you briefly invincible. Reach the flag to finish a level — or
+defeat the boss to win. You have three lives.
+
 ## Controls
 
-| Key            | Action            |
-|----------------|-------------------|
-| ← / →          | Move              |
-| Space          | Jump              |
-| Escape         | Pause / resume    |
-| ↑ / ↓ + Enter  | Navigate menus    |
+| Key            | Action                      |
+|----------------|-----------------------------|
+| ← / →          | Move                        |
+| Space          | Jump                        |
+| Escape         | Pause / resume              |
+| ↑ / ↓ + Enter  | Navigate menus              |
+| Enter / Space  | Advance the title & story   |
 
 ## Documentation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,46 +1,53 @@
 # Roadmap
 
 The path from the original school-project prototype to a production-ready
-platformer. Items are dependency-ordered; each is delivered as its own PR that
-must compile (enforced by CI) and keep the docs in sync.
+platformer. Each item was delivered as its own PR that compiles (enforced by
+CI) and keeps the docs in sync.
 
 Status: ☐ todo · ◐ in progress · ☑ done
 
 ## Phase 0 — Infrastructure
 - ☑ **CI + build hygiene** — GitHub Actions (Ubuntu + macOS), portable CMake, `.gitignore`, docs.
+- ☑ **Headless unit tests** run in CI (`ctest`).
 
-## Phase 1 — Correctness (bug fixes, no big refactor)
-- ☐ **Critical bug sweep** — uninitialised members; `expandArray` value-init; enemy fall cleanup; remove double-camera scroll; stomp detection via velocity + bounds; no-op/dead code.
-- ☐ **Input & high-score fixes** — fix text entry (unicode vs scancode), make registration commit + transition, read the real high-score count, guard malformed files.
+## Phase 1 — Correctness
+- ☑ **Critical bug sweep** — uninitialised members; stale `getPosition`; `expandArray` value-init; enemy fall cleanup; stomp detection via velocity + bounds; no-op/dead code.
+- ☑ **Input & high-score fixes** — text entry (unicode vs scancode), registration commit + transition, real high-score count, malformed-file guards.
+- ☑ **Audio** — buffered SFX vs streamed theme; macOS OpenAL crash documented.
 
 ## Phase 2 — Foundation refactors
-- ☑ **`GameState` enum** — replace the four-boolean state soup with one state machine.
-- ☑ **`TileType` registry** — one source of truth for tile semantics (sprite, solidity, finish, spawn), shared by `Map` and `Collision`.
-- ☑ **`LevelManager`** — load multiple level data files; explicit per-level dimensions; level progression.
+- ☑ **`GameState` machine** — replaces the four-boolean state soup.
+- ☑ **`TileType` registry** — one source of truth for tile semantics, shared by `Map` and `Collision`.
+- ☑ **`LevelManager`** — multiple level data files; level progression with carried stats.
 
 ## Phase 3 — Core systems
-- ◐ **Lives + respawn** (checkpoints pending)
-- ☐ **Score + persistent screen-space HUD + level-complete results screen.**
+- ☑ **Lives + respawn** (checkpoints pending).
+- ☑ **Score + screen-space HUD + victory results screen.**
 - ☑ **Mario power state** (small / big / star invincibility).
-- ◐ **Power-up system** (coin, speed, grow, star; typed via LootType).
+- ☑ **Power-up system** (coin, speed, grow, star; typed via `LootType`).
 
 ## Phase 4 — Enemies & combat
-- ☐ **Enemy hierarchy + deterministic AI** (Goomba, Koopa, flyer, spiky).
-- ☐ **Projectiles / fireballs.**
+- ☑ **Frame-rate-independent flying enemy.**
+- ☐ **Further enemy variety** (shells/spiky) and **projectiles / fireballs.**
 
 ## Phase 5 — Content, endgame & narrative
 - ☑ **Multiple authored levels + difficulty curve** (6 levels incl. boss).
 - ☑ **Boss enemy + endgame arena.**
-- ☐ **Title screen + story/cutscene + win/credits flow.**
+- ☑ **Title screen + story intro + victory flow.**
 
 ## Phase 6 — Polish & robustness
-- ◐ **UI/HUD module** decoupled from shared menu slots.
-- ☑ **Resource manager + smart pointers** (shared TextureManager + vector<unique_ptr>) (shared textures, `vector<unique_ptr>`).
+- ☑ **`Hud` module** decoupled from the menu slots; screen-space menus + pause overlay.
+- ☑ **Resource manager + smart pointers** — shared `TextureManager`, `vector<unique_ptr>` entities.
 - ☐ **Save/progression persistence + externalised config.**
+
+## Backlog (nice-to-have)
+- Mid-level checkpoints.
+- Fire flower + projectiles; more enemy archetypes.
+- Persisted progression / unlocks and tunables in a config file.
 
 ## Design principle
 
-Once the `GameState` enum, `TileType` registry, and `LevelManager` exist, new
-content (levels, the boss arena, cutscenes) becomes **data files plus small
-subclasses** — never edits to the main loop. That is what keeps the codebase
-from regressing into magic-number / boolean spaghetti.
+With the `GameState` machine, the `TileType` registry, and the `LevelManager`
+in place, new content (levels, the boss arena, cutscenes) is **data files plus
+small subclasses** — never edits to the main loop. That is what keeps the
+codebase from regressing into magic-number / boolean spaghetti.


### PR DESCRIPTION
Brings docs in line with the shipped game: roadmap status updated (phases 0-3, 5 and most of 6 done; nice-to-haves moved to a backlog), README describes the actual game (five worlds + boss, power-ups, lives) and full controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)